### PR TITLE
`Clock` feedback

### DIFF
--- a/src/protocol/clock.rs
+++ b/src/protocol/clock.rs
@@ -74,9 +74,9 @@ impl<const T: usize> From<u64> for UnixClock<{ T }> {
     }
 }
 
-impl<const T: usize> Into<u64> for UnixClock<{ T }> {
-    fn into(self) -> u64 {
-        self.0.as_secs()
+impl<const T: usize> From<UnixClock<{ T }>> for u64 {
+    fn from(unix_clock: UnixClock<{ T }>) -> Self {
+        unix_clock.0.as_secs()
     }
 }
 

--- a/src/protocol/clock.rs
+++ b/src/protocol/clock.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-pub trait Clock: Sized + Div + From<Duration> + From<u64> + Into<u64> + From<u32> + TryInto<u32> {
+pub trait Time: Sized + Div + From<Duration> + From<u64> + Into<u64> + From<u32> + TryInto<u32> {
     fn now() -> Self;
     fn after(period: &Duration) -> Self;
 
@@ -14,22 +14,22 @@ pub trait Clock: Sized + Div + From<Duration> + From<u64> + Into<u64> + From<u32
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-pub struct UnixClock<const T: usize>(pub Duration);
+pub struct UnixTime<const T: usize>(pub Duration);
 
-pub enum ClockType {
-    LocalClock,
-    FixedClock,
+pub enum Clock {
+    SystemTime,
+    FixedTime,
 }
 
 #[cfg(not(test))]
-pub type DefaultClock = UnixClock<{ ClockType::LocalClock as usize }>;
+pub type DefaultTime = UnixTime<{ Clock::SystemTime as usize }>;
 
 #[cfg(test)]
-pub type DefaultClock = UnixClock<{ ClockType::FixedClock as usize }>;
+pub type DefaultTime = UnixTime<{ Clock::FixedTime as usize }>;
 
 pub type Periods = u128;
 
-impl Clock for UnixClock<{ ClockType::LocalClock as usize }> {
+impl Time for UnixTime<{ Clock::SystemTime as usize }> {
     fn now() -> Self {
         Self(SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap())
     }
@@ -45,7 +45,7 @@ impl Clock for UnixClock<{ ClockType::LocalClock as usize }> {
     }
 }
 
-impl Clock for UnixClock<{ ClockType::FixedClock as usize }> {
+impl Time for UnixTime<{ Clock::FixedTime as usize }> {
     fn now() -> Self {
         Self(Duration::ZERO)
     }
@@ -55,38 +55,38 @@ impl Clock for UnixClock<{ ClockType::FixedClock as usize }> {
     }
 }
 
-impl<const T: usize> Div for UnixClock<{ T }> {
+impl<const T: usize> Div for UnixTime<{ T }> {
     type Output = Periods;
     fn div(self, rhs: Self) -> Self::Output {
         self.0.as_nanos() / rhs.0.as_nanos()
     }
 }
 
-impl<const T: usize> From<Duration> for UnixClock<{ T }> {
+impl<const T: usize> From<Duration> for UnixTime<{ T }> {
     fn from(duration: Duration) -> Self {
         Self(duration)
     }
 }
 
-impl<const T: usize> From<u64> for UnixClock<{ T }> {
+impl<const T: usize> From<u64> for UnixTime<{ T }> {
     fn from(int: u64) -> Self {
         Self(Duration::new(int, 0))
     }
 }
 
-impl<const T: usize> From<UnixClock<{ T }>> for u64 {
-    fn from(unix_clock: UnixClock<{ T }>) -> Self {
+impl<const T: usize> From<UnixTime<{ T }>> for u64 {
+    fn from(unix_clock: UnixTime<{ T }>) -> Self {
         unix_clock.0.as_secs()
     }
 }
 
-impl<const T: usize> From<u32> for UnixClock<{ T }> {
+impl<const T: usize> From<u32> for UnixTime<{ T }> {
     fn from(int: u32) -> Self {
         Self(Duration::new(int.into(), 0))
     }
 }
 
-impl<const T: usize> TryInto<u32> for UnixClock<{ T }> {
+impl<const T: usize> TryInto<u32> for UnixTime<{ T }> {
     type Error = <u32 as TryFrom<u64>>::Error;
 
     fn try_into(self) -> Result<u32, Self::Error> {

--- a/src/tracker/key.rs
+++ b/src/tracker/key.rs
@@ -7,7 +7,7 @@ use rand::distributions::Alphanumeric;
 use serde::Serialize;
 
 use crate::AUTH_KEY_LENGTH;
-use crate::protocol::clock::{DefaultClock, Clock};
+use crate::protocol::clock::{DefaultTime, Time};
 
 pub fn generate_auth_key(seconds_valid: u64) -> AuthKey {
     let key: String = thread_rng()
@@ -20,12 +20,12 @@ pub fn generate_auth_key(seconds_valid: u64) -> AuthKey {
 
     AuthKey {
         key,
-        valid_until: Some(DefaultClock::after_sec(seconds_valid).0),
+        valid_until: Some(DefaultTime::after_sec(seconds_valid).0),
     }
 }
 
 pub fn verify_auth_key(auth_key: &AuthKey) -> Result<(), Error> {
-    let current_time = DefaultClock::now();
+    let current_time = DefaultTime::now();
     if auth_key.valid_until.is_none() { return Err(Error::KeyInvalid); }
     if auth_key.valid_until.unwrap() <= current_time.0 { return Err(Error::KeyExpired); }
 

--- a/src/udp/connection/connection_cookie.rs
+++ b/src/udp/connection/connection_cookie.rs
@@ -9,7 +9,7 @@ use cipher::generic_array::GenericArray;
 use cipher::{BlockDecrypt, BlockEncrypt, BlockSizeUser};
 
 use crate::keys::DEFAULT_KEY;
-use crate::protocol::clock::{DefaultClock, Clock};
+use crate::protocol::clock::{DefaultTime, Time};
 
 type BlowfishArray = GenericArray<u8, <Blowfish<LittleEndian> as BlockSizeUser>::BlockSize>;
 
@@ -48,8 +48,8 @@ impl HashedCookie {
         };
         
         let now_maybe_next = match past {
-            true => DefaultClock::after(&after_maybe),
-            false => DefaultClock::after(&(lifetime + after_maybe)),
+            true => DefaultTime::after(&after_maybe),
+            false => DefaultTime::after(&(lifetime + after_maybe)),
         };
 
         let life_period =  now_maybe_next / lifetime.into();
@@ -97,7 +97,7 @@ impl ConnectionCookie<KeyedImage> for WitnessCookie {
     type Error = &'static str;
 
     fn new(client_image: KeyedImage, lifetime: Duration) -> Self {
-        let expiry_u32: u32 = DefaultClock::after(&lifetime).try_into().unwrap();
+        let expiry_u32: u32 = DefaultTime::after(&lifetime).try_into().unwrap();
 
         let mut hasher = DefaultHasher::default();
         hasher.write_u32(expiry_u32);
@@ -129,7 +129,7 @@ impl ConnectionCookie<KeyedImage> for WitnessCookie {
             None => Duration::ZERO,
         };
 
-        let now_u32 = DefaultClock::after(&after_maybe).try_into().unwrap();
+        let now_u32 = DefaultTime::after(&after_maybe).try_into().unwrap();
 
         if expiry_u32 <= now_u32 {
             return Err("Expired connection id");
@@ -153,7 +153,7 @@ impl ConnectionCookie<PlainImage> for EncryptedCookie {
     type Error = &'static str;
 
     fn new(client_image: PlainImage, lifetime: Duration) -> Self {
-        let expiry_u32: u32 = DefaultClock::after(&lifetime).try_into().unwrap();
+        let expiry_u32: u32 = DefaultTime::after(&lifetime).try_into().unwrap();
 
         let id_clear: Vec<u8> = [&client_image.value()[0..4], &expiry_u32.to_le_bytes().as_slice()].concat();
 
@@ -193,7 +193,7 @@ impl ConnectionCookie<PlainImage> for EncryptedCookie {
             None => Duration::ZERO,
         };
 
-        let now = DefaultClock::after(&after_maybe);
+        let now = DefaultTime::after(&after_maybe);
 
         let expiry = u32::from_le_bytes(expiry_bytes);
 


### PR DESCRIPTION
hi @da2ce7, this is my feedback for [this](https://github.com/torrust/torrust-tracker/pull/77#issuecomment-1241328314).

It's not finished yet.

- [x] Prefer From trait over Into.
- [x] Rename clock
- [ ] Allow mocking the time in tests with a given time.

Why did I rename the `Clock`?

The `Clock` return an instance of itself, and it's the time. I see the `Clock` as the service and the `Time` as the value object. In this implementation, you do not use the service, only a value object that instantiates by itself.

With the new name, you see:

![image](https://user-images.githubusercontent.com/58816/189316020-a74a1599-4dd2-444e-a92f-88db68733bba.png)

With the previous name, you read:

![image](https://user-images.githubusercontent.com/58816/189316246-eeb80e79-1348-4cee-9330-7a87985befd2.png)

It's a little weird that the variable `current_time` is a `UnixClock`.